### PR TITLE
Amends _bower.json to fix Sass punctuation problem

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -2,7 +2,7 @@
   "name": "<%= _.slugify(appname) %>",
   "version": "0.0.0",
   "dependencies": {
-    <% if (angular) { %>"angular": "~1.2.9",
-    <% } if (less) { %>"lesshat": "~3.0.0"<% } %>
+    <% if (angular) { %>"angular": "~1.2.9"<% } if (less) { %>,
+    "lesshat": "~3.0.0"<% } %>
   }
 }


### PR DESCRIPTION
I moved a comma into the if (less) section.

Previously, if you used the generator to make an app with Sass, the bower.json file was generated with an extra comma on line 5. This comma prevented bower install from working and had to be removed by hand. Now the comma is included in the if (less) block, so if you choose Sass the comma will not be inserted.
